### PR TITLE
Avoid sending a host header that doesn't match the target host

### DIFF
--- a/lib/http/server.ms
+++ b/lib/http/server.ms
@@ -100,6 +100,7 @@ export class Server {
 
     options.path    = req.url;
     options.headers = req.headers;
+    options.headers.host = options.host;
     if (this.options.keepAlive) options.headers.connection = "keep-alive";
 
     var req = http.request(options);


### PR DESCRIPTION
When a request is sent to a backend, the `Host` header field contains the hostname of the front server.
If one of the backend serves the request based on the `Host` header, it will fail.

ie:

```
var back = front.back('main-www');
back.server('my-registry', 'http://127.0.0.1:2000');
var backup = back.backup();
backup.server('global-registry', 'http://registry.npmjs.org/');
backup.server('eu-registry', 'http://registry.npmjs.eu/');
```

In this case, the `global-registry` and `eu-registry` won't work.

By settings the `Host` header field to the hostname extracted from the backend url, it will work.
